### PR TITLE
Using the esnext compile options defined in loader query string

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,15 @@ module.exports = {
     }
 };
 ```
+
+You can set `esnext` configs with query parameters. [All esnext options](https://github.com/esnext/esnext/blob/50b89f461cc7ca93484928540ebbf3e6ba58f302/lib/index.js#L61-L100) are available except for source map.
+
+```js
+module.exports = {
+    module: {
+        loaders: [
+            { test: /\.js$/, loader: 'esnext?+arrowFunction,-computedPropertyKeys' }
+        ]
+    }
+};
+```

--- a/index.js
+++ b/index.js
@@ -1,13 +1,24 @@
 var esnext = require('esnext');
+var loaderUtils = require('loader-utils');
+
+function compileOptions(query, options) {
+    Object.keys(query).forEach(function (name) {
+        options[name] = query[name];
+    });
+
+    return options;
+}
 
 module.exports = function(content) {
     if (this.cacheable)
         this.cacheable();
 
-    var result = esnext.compile(content, {
+    var query = loaderUtils.parseQuery(this.query);
+
+    var result = esnext.compile(content, compileOptions(query, {
         sourceFileName: this.resourcePath,
-        sourceMapName: 'map.json'
-    });
+        sourceMapName: this.resourcePath + '.map'
+    }));
 
     var cb = this.async();
     if (!cb)

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "webpack": "^1.4.0-beta6"
   },
   "dependencies": {
-    "esnext": "^0.10.0"
+    "esnext": "^0.10.0",
+    "loader-utils": "^0.2.4"
   }
 }


### PR DESCRIPTION
I have added an option to pass esnext options with loader query string. 

But when I set `arrowFunction` to false, esnext still transpile arrow functions. It seems there is a bug in esnext module.
